### PR TITLE
bad condition when there is only one word in the string, fixed it 

### DIFF
--- a/EXAM02/3-last_word/last_word.c
+++ b/EXAM02/3-last_word/last_word.c
@@ -7,7 +7,7 @@ void	last_word(char *str)
 	i -= 1;
 	while(str[i] == '\t' || str[i] == 32)
 		i--;
-	while (i > 0)
+	while (i >= 0)
 	{	if(str[i] == 32 || str[i] == '\t')
 			break;
 		i--;


### PR DESCRIPTION
changed the condition while ( I > 0) to while ( i >= 0) because if there was only one word and nothing else in the string ( like for example "test") it would print the word but leave out its first letter. The reason behind this issue is the fact that in our example , "t" is str[0], but zero is excluded due to the condition.